### PR TITLE
fix: Please provide binary data as `Uint8Array`, rather than `Buffer`.

### DIFF
--- a/src/handlers/readPdf.ts
+++ b/src/handlers/readPdf.ts
@@ -183,11 +183,11 @@ const loadPdfDocument = async (
   source: { path?: string | undefined; url?: string | undefined }, // Explicitly allow undefined
   sourceDescription: string
 ): Promise<pdfjsLib.PDFDocumentProxy> => {
-  let pdfDataSource: Buffer | { url: string };
+  let pdfDataSource: Uinit8Array | { url: string };
   try {
     if (source.path) {
       const safePath = resolvePath(source.path); // resolvePath handles security checks
-      pdfDataSource = await fs.readFile(safePath);
+      pdfDataSource = Uinit8Array.from(await fs.readFile(safePath));
     } else if (source.url) {
       pdfDataSource = { url: source.url };
     } else {


### PR DESCRIPTION
https://github.com/mozilla/pdf.js/blob/45cbe8bb0dc4c1c16ca8ec404463dd0f4d79ce6d/src/display/api.js#L236

<img width="1432" height="1194" alt="image" src="https://github.com/user-attachments/assets/4a907df8-75e4-4cb3-8010-8db726844eaf" />

this function needs an ArrayBuffer insteads of BufferLike.

if using Buffer, it will broken

https://github.com/mozilla/pdf.js/blob/45cbe8bb0dc4c1c16ca8ec404463dd0f4d79ce6d/src/display/api.js#L568C6-L568C74

<img width="652" height="304" alt="image" src="https://github.com/user-attachments/assets/8f68d444-fb03-482e-806d-f0a80db0869c" />


